### PR TITLE
Use gcovr --exclude-throw-branches as it is not possible to mark them…

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -13,7 +13,8 @@ set(COVERAGE_OUTPUT_FILE coverage_sonar.xml)
 add_custom_target(
     generate_coverage ALL
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND ${GCOVR_PATH} --sonarqube build/${COVERAGE_OUTPUT_FILE} -s --filter src 2> gcov_run_cmake.out
+    # use --exclude-throw-branches to get branch coverage more sensible per https://gcovr.com/en/stable/faq.html
+    COMMAND ${GCOVR_PATH} --exclude-throw-branches --sonarqube build/${COVERAGE_OUTPUT_FILE} -s --filter src 2> gcov_run_cmake.out
     DEPENDS run_unit_test
     )
 


### PR DESCRIPTION
… as covered

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR sets the --exclude-throw-branches flag when running gcovr.  Without this the code coverage report shows many unfollowed branched where exceptions are used and there is no way to really cover them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
