### PR TITLE
Allow for 0 SO_VERSION

### DIFF
--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -15,13 +15,17 @@ endif()
 get_target_property(target_type ${PROJECT_NAME} TYPE)
 if (target_type STREQUAL "SHARED_LIBRARY")
     get_target_property(so_version ${PROJECT_NAME} SOVERSION)
-    if (NOT so_version)
-        message( FATAL_ERROR "Target property SOVERSION must be defined for shared library packages." )
-    endif()
+    # so_version evaluates to false when set to zero despite having a value 
+    # see (https://cmake.org/cmake/help/v3.0/command/if.html). It evaluates to
+    # so_version-NOTFOUND when no value is present. It is always defined whether
+    # the property exists or not (see https://cmake.org/cmake/help/latest/command/get_target_property.html)
+    if((NOT so_version EQUAL 0 ) AND  (NOT so_version))
+      message( FATAL_ERROR "Target property SOVERSION must be defined for shared library packages." )
+    endif() 
     set (PACKAGE_VERSION ${so_version})
 endif()
 
-if (NOT PACKAGE_VERSION)
+if (NOT DEFINED PACKAGE_VERSION)
     message( FATAL_ERROR "PACKAGE_VERSION must be defined for packages." )
 endif()
 

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -15,12 +15,10 @@ endif()
 get_target_property(target_type ${PROJECT_NAME} TYPE)
 if (target_type STREQUAL "SHARED_LIBRARY")
     get_target_property(so_version ${PROJECT_NAME} SOVERSION)
-    # so_version evaluates to false when set to zero despite having a value 
-    # see (https://cmake.org/cmake/help/v3.0/command/if.html). It evaluates to
-    # so_version-NOTFOUND when no value is present. It is always defined whether
-    # the property exists or not (see https://cmake.org/cmake/help/latest/command/get_target_property.html)
-    if((NOT so_version EQUAL 0 ) AND  (NOT so_version))
-      message( FATAL_ERROR "Target property SOVERSION must be defined for shared library packages." )
+    # Check if so_version is empty or not found to allow for version 0
+    # which is normally treated the same as so_version-NOTFOUND in a condition.
+    if ("${so_version}" STREQUAL "" OR "${so_version}" STREQUAL "so_version-NOTFOUND")
+        message( FATAL_ERROR "Target property SOVERSION must be defined for shared library packages." )
     endif() 
     set (PACKAGE_VERSION ${so_version})
 endif()


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Allow for 0 SO_Version. Prior to this fix assigning 0 as target SO_VERSION would CMake error and print fatal message `Target property SOVERSION must be defined for shared library packages.`.
## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
Fix carma-builds base image
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally with carma-geodetic-lib
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
