### PR TITLE
Fix Testing.cmake to not require pthread

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -11,7 +11,7 @@ IF(NOT DEFINED ENV{BUILD_ARCHITECTURE} AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/te
     target_link_libraries(${UNIT_TEST} PUBLIC 
         ${PROJECT_NAME}
         ${TEST_LINK_LIBRARIES}
-        gtest)
+        GTest::gtest_main)
     add_test(NAME ${UNIT_TEST} COMMAND ${UNIT_TEST})
     add_custom_target(
         run_unit_test ALL

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -13,6 +13,7 @@ IF(NOT DEFINED ENV{BUILD_ARCHITECTURE} AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/te
         ${TEST_LINK_LIBRARIES}
         GTest::gtest_main)
     add_test(NAME ${UNIT_TEST} COMMAND ${UNIT_TEST})
+    include(GoogleTest)
     gtest_discover_tests(${UNIT_TEST})
     add_custom_target(
         run_unit_test ALL

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -13,6 +13,7 @@ IF(NOT DEFINED ENV{BUILD_ARCHITECTURE} AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/te
         ${TEST_LINK_LIBRARIES}
         GTest::gtest_main)
     add_test(NAME ${UNIT_TEST} COMMAND ${UNIT_TEST})
+    gtest_discover_tests(${UNIT_TEST})
     add_custom_target(
         run_unit_test ALL
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fix Testing.cmake to not require pthread. Correct way to link google test in CMake is documented here https://cmake.org/cmake/help/latest/module/FindGTest.html
## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
Currently not calling find_package( Threads) causes linker error when including Testing.cmake. This resolves the issue.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested by making changes locally and building and running tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
