### PR TITLE
Fix to CPack

### DIFF
--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -93,16 +93,18 @@ string(REPLACE "Codename:" "" UBUNTU_CODENAME "${UBUNTU_CODENAME}")
 # Strip again to ensure there are no leading/trailing spaces after removal
 string(STRIP "${UBUNTU_CODENAME}" UBUNTU_CODENAME)
 message(STATUS "Ubuntu Codename:${UBUNTU_CODENAME}")
-# get architecture
-find_program(DPKG_CMD dpkg)
-if(NOT DPKG_CMD)
-  message(STATUS "CPackDeb: Can not find dpkg in your path, default to i386.")
-  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386)
+if (NOT CPACK_DEBIAN_PACKAGE_ARCHITECTURE)
+    # get architecture
+    find_program(DPKG_CMD dpkg)
+    if(NOT DPKG_CMD)
+    message(STATUS "CPackDeb: Can not find dpkg in your path, default to i386.")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386)
+    endif()
+    execute_process(COMMAND "${DPKG_CMD}" --print-architecture
+    OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 endif()
-execute_process(COMMAND "${DPKG_CMD}" --print-architecture
-  OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
 # package name for deb. If set, then instead of some-application-0.9.2-Linux.deb
 # you'll get some-application_0.9.2_jammy_amd64.deb (note the underscores too). This name 
 # prevents overwriting and the DEB_DEFAULT without ubuntu distro does not

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -93,7 +93,10 @@ string(REPLACE "Codename:" "" UBUNTU_CODENAME "${UBUNTU_CODENAME}")
 # Strip again to ensure there are no leading/trailing spaces after removal
 string(STRIP "${UBUNTU_CODENAME}" UBUNTU_CODENAME)
 message(STATUS "Ubuntu Codename:${UBUNTU_CODENAME}")
-if (NOT CPACK_DEBIAN_PACKAGE_ARCHITECTURE)
+# Get Archictecture taken from CPackDeb.cmake
+if(CPACK_DEB_PACKAGE_COMPONENT AND CPACK_DEBIAN_${_local_component_name}_PACKAGE_ARCHITECTURE)
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_DEBIAN_${_local_component_name}_PACKAGE_ARCHITECTURE}")
+elseif(NOT CPACK_DEBIAN_PACKAGE_ARCHITECTURE)
     # get architecture
     find_program(DPKG_CMD dpkg)
     if(NOT DPKG_CMD)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Found bug introduced from my changes for cross compilation targets. Targets cross compiled will return amd64 under current changes. This update addresses this by not overwriting architecture set by the cross compilation environment variables
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
